### PR TITLE
Removed darwin/386 From Gox Build List

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ dist:
 	mkdir -p dist
 
 gox:
-	CGO_ENABLED=0 gox -ldflags="-s -w" -output="dist/{{.Dir}}_{{.OS}}_{{.Arch}}"
+	CGO_ENABLED=0 gox -ldflags="-s -w" -osarch '!darwin/386' -output="dist/{{.Dir}}_{{.OS}}_{{.Arch}}"
 
 draft:
 	ghr -draft v$(VERSION) dist/


### PR DESCRIPTION
Go 1.15 deprecated 32-bit macOS builds.
A suggested fix is to remove it from the build list until this change is patched into gox.

https://github.com/mitchellh/gox/issues/146