### PR TITLE
Removed gox binaries from VCS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 *.so
 *.dylib
 
+dist/
 # Test binary, built with `go test -c`
 *.test
 


### PR DESCRIPTION
The compiled gox binaries should not be tracked by the VCS to avoid accidental commits